### PR TITLE
Fix entrypoint for server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
         image: apisearchio/search-server:new-relic
         container_name: apisearch.server
         networks: [apisearch]
-        command: ["sh", /server-pm-entrypoint.sh]
+        command: ["sh", /server-entrypoint.sh]
         depends_on:
             - redis
         ports:


### PR DESCRIPTION
File `server-pm-entrypoint.sh` doesn't exists in https://github.com/apisearch-io/search-server/tree/master/docker,  we should be use `server-entrypoint.sh` instead.